### PR TITLE
barebones binary for downloading Groth parameters in CI environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
         default: golang
       golangci-lint-version:
         type: string
-        default: 1.17.1
+        default: 1.21.0
       concurrency:
         type: string
         default: '2'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A program used to download Groth parameters and verifying keys used by the Filecoin network
 
+## Usage
+
+```
+go run ./paramfetch.go 1024 /tmp/parameters.json
+```
+
 ## License
 
 Dual-licensed under [MIT](https://github.com/filecoin-project/go-paramfetch/blob/master/LICENSE-MIT) + [Apache 2.0](https://github.com/filecoin-project/go-paramfetch/blob/master/LICENSE-APACHE)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 A program used to download Groth parameters and verifying keys used by the Filecoin network
 
-## Usage
-
-```
-go run ./paramfetch.go 1024 /tmp/parameters.json
-```
-
 ## License
 
 Dual-licensed under [MIT](https://github.com/filecoin-project/go-paramfetch/blob/master/LICENSE-MIT) + [Apache 2.0](https://github.com/filecoin-project/go-paramfetch/blob/master/LICENSE-APACHE)

--- a/paramfetch/paramfetch.go
+++ b/paramfetch/paramfetch.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+
+	build "github.com/filecoin-project/go-paramfetch"
+)
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+func main() {
+	sectorSize := os.Args[1]
+	paramsJsonPath := os.Args[2]
+
+	n, err := strconv.ParseUint(sectorSize, 10, 64)
+	check(err)
+
+	dat, err := ioutil.ReadFile(paramsJsonPath)
+	check(err)
+
+	err = build.GetParams(dat, n)
+	check(err)
+}


### PR DESCRIPTION
## Why does this PR exist?

In its current form, library consumers need to call `GetParams` themselves. It would be nice for us to roll a basic little binary for them to use instead of having to write that code themselves.

## What's in this PR?

This PR adds the barebones-iest of binaries which can be used to download verifying keys and Groth parameters.