### PR TITLE
change url to use collab ipfs cluster

### DIFF
--- a/paramfetch.go
+++ b/paramfetch.go
@@ -22,7 +22,7 @@ import (
 var log = logging.Logger("build")
 
 //const gateway = "http://198.211.99.118/ipfs/"
-const gateway = "https://ipfs.io/ipfs/"
+const gateway = "https://proofs.filecoin.io/ipfs/"
 const paramdir = "/var/tmp/filecoin-proof-parameters"
 const dirEnv = "FIL_PROOFS_PARAMETER_CACHE"
 


### PR DESCRIPTION
proof parameters are pinned in collab cluster instead of directly on ipfs public gateways