### PR TITLE
fix: Force VK integrity check regardless of TRUST_PARAMS

### DIFF
--- a/paramfetch.go
+++ b/paramfetch.go
@@ -153,8 +153,19 @@ func (ft *fetch) maybeFetchAsync(ctx context.Context, name string, info paramFil
 	}()
 }
 
+func hasTrustableExtension(path string) bool {
+	// known extensions include "vk", "srs", and "params"
+	// expected to only treat "params" ext as trustable
+	// by blacklisting "vk" and "srs" to ensure new exts
+	// will not change the behavior
+
+	// we must always check "vk" and "srs" files to ensure
+	// only valid blocks are built upon
+	return !strings.HasSuffix(path, "vk") && !strings.HasSuffix(path, "srs")
+}
+
 func (ft *fetch) checkFile(path string, info paramFile) error {
-	if os.Getenv("TRUST_PARAMS") == "1" && !strings.HasSuffix(path, "vk") {
+	if os.Getenv("TRUST_PARAMS") == "1" && hasTrustableExtension(path) {
 		log.Debugf("Skipping param check: %s", path)
 		log.Warn("Assuming parameter files are ok. DO NOT USE IN PRODUCTION")
 		return nil

--- a/paramfetch.go
+++ b/paramfetch.go
@@ -154,7 +154,8 @@ func (ft *fetch) maybeFetchAsync(ctx context.Context, name string, info paramFil
 }
 
 func (ft *fetch) checkFile(path string, info paramFile) error {
-	if os.Getenv("TRUST_PARAMS") == "1" {
+	if os.Getenv("TRUST_PARAMS") == "1" && !strings.HasSuffix(path, "vk") {
+		log.Debugf("Skipping param check: %s", path)
 		log.Warn("Assuming parameter files are ok. DO NOT USE IN PRODUCTION")
 		return nil
 	}

--- a/paramfetch_test.go
+++ b/paramfetch_test.go
@@ -85,7 +85,7 @@ func TestGetParamsParallel(t *testing.T) {
 	wg.Wait()
 }
 
-func TestCheckFileIgnoresNonVKExtension(t *testing.T) {
+func TestCheckFileIgnoresUntrustableExtension(t *testing.T) {
 	const mockParamInfoBytes = `{
 			"cid": "Qmxxxxxdoesntexist",
 			"digest": "0e0958009936b9d5e515ec97b8cb792d",
@@ -108,5 +108,8 @@ func TestCheckFileIgnoresNonVKExtension(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = ft.checkFile(filepath.Join(".", "should_check_and_fail.vk"), mockParamInfo)
+	assert.Error(t, err)
+
+	err = ft.checkFile(filepath.Join(".", "also_check_and_fail.srs"), mockParamInfo)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
part of https://github.com/filecoin-project/lotus/issues/6640

The intention of this change is to ensure that the verification keys are always checked regardless of the state of `TRUST_PARAMS` to ensure that miners are building on blocks which have been properly verified.

I have also reviewed the logic and don't believe there are pre-mature exits are possible without errors being checked for and should ensure that every entry within `paramBytes` will be considered at least once and ensure ALL verification keys will be (1) present and (2) have the correct SHA digest. This should satify the requirements of #6640.