### PR TITLE
fix: Prefer allowlist for managing trustable extensions

### DIFF
--- a/paramfetch.go
+++ b/paramfetch.go
@@ -156,12 +156,8 @@ func (ft *fetch) maybeFetchAsync(ctx context.Context, name string, info paramFil
 func hasTrustableExtension(path string) bool {
 	// known extensions include "vk", "srs", and "params"
 	// expected to only treat "params" ext as trustable
-	// by blacklisting "vk" and "srs" to ensure new exts
-	// will not change the behavior
-
-	// we must always check "vk" and "srs" files to ensure
-	// only valid blocks are built upon
-	return !strings.HasSuffix(path, "vk") && !strings.HasSuffix(path, "srs")
+	// via allowlist
+	return strings.HasSuffix(path, "params")
 }
 
 func (ft *fetch) checkFile(path string, info paramFile) error {


### PR DESCRIPTION
Resolves https://github.com/filecoin-project/go-paramfetch/pull/17/files#r708366414