### PR TITLE
Disable TRUST_PARAMS

### DIFF
--- a/paramfetch.go
+++ b/paramfetch.go
@@ -162,9 +162,9 @@ func hasTrustableExtension(path string) bool {
 
 func (ft *fetch) checkFile(path string, info paramFile) error {
 	if os.Getenv("TRUST_PARAMS") == "1" && hasTrustableExtension(path) {
-		log.Debugf("Skipping param check: %s", path)
-		log.Warn("Assuming parameter files are ok. DO NOT USE IN PRODUCTION")
-		return nil
+		log.Warn("TRUST_PARAMS has been disabled around the SnapDeals upgrade, checking params...")
+		//log.Debugf("Skipping param check: %s", path)
+		//log.Warn("Assuming parameter files are ok. DO NOT USE IN PRODUCTION")
 	}
 
 	checkedLk.Lock()

--- a/paramfetch_test.go
+++ b/paramfetch_test.go
@@ -104,8 +104,9 @@ func TestCheckFileIgnoresUntrustableExtension(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	err = ft.checkFile(filepath.Join(".", "should_ignore.params"), mockParamInfo)
-	assert.NoError(t, err)
+	// TODO: Return when TRUST_PARAMS has been re-enabled
+	//err = ft.checkFile(filepath.Join(".", "should_ignore.params"), mockParamInfo)
+	//assert.NoError(t, err)
 
 	err = ft.checkFile(filepath.Join(".", "should_check_and_fail.vk"), mockParamInfo)
 	assert.Error(t, err)


### PR DESCRIPTION
Out of an abundance of caution, since we're uploading testnet params that will then be replaced by the real thing for SnapDeals.